### PR TITLE
Standard enemy archetypes

### DIFF
--- a/apps/web/src/game/combat/CombatTypes.ts
+++ b/apps/web/src/game/combat/CombatTypes.ts
@@ -10,6 +10,7 @@ export type DamageEvent = {
   hitPoint: Vector3 | null;
   timestamp: number;
   staggerAmount?: number;
+  sourcePosition?: Vector3;
 };
 
 export type HealthComponent = {

--- a/apps/web/src/game/core/GameCanvas.tsx
+++ b/apps/web/src/game/core/GameCanvas.tsx
@@ -12,6 +12,8 @@ import { AbilitySystem } from "../abilities/AbilitySystem";
 import { playerLoadout } from "../abilities/AbilityConfigs";
 import { PlayerMovementSystem } from "../systems/PlayerMovementSystem";
 import { ThirdPersonCamera } from "../systems/ThirdPersonCamera";
+import { EnemyAISystem } from "../systems/EnemyAISystem";
+import { gruntConfig, bruiserConfig, controllerConfig } from "../entities/enemies/EnemyConfigs";
 
 type Props = {
   className?: string;
@@ -127,6 +129,17 @@ export function GameCanvas({ className, onHudUpdate }: Props) {
       dummyByMesh
     );
 
+    const enemySystem = new EnemyAISystem(scene, combatResolver, playerCombatant, movementSystem);
+    const spawnWave = () => {
+      enemySystem.clear();
+      enemySystem.spawnEnemy(gruntConfig, new Vector3(-10, 1.1, -6), ["hardened"]);
+      enemySystem.spawnEnemy(gruntConfig, new Vector3(-8, 1.1, -2));
+      enemySystem.spawnEnemy(gruntConfig, new Vector3(-6, 1.1, 2));
+      enemySystem.spawnEnemy(bruiserConfig, new Vector3(10, 1.1, 6), ["volatile"]);
+      enemySystem.spawnEnemy(controllerConfig, new Vector3(6, 1.1, -10), ["adaptive"]);
+    };
+    spawnWave();
+
     let fovMode: "normal" | "dash" = "normal";
     let lockOnActive = false;
     const frontDamageSource = new Vector3();
@@ -180,6 +193,9 @@ export function GameCanvas({ className, onHudUpdate }: Props) {
           staggerAmount: 6,
         });
       }
+      if (event.code === "KeyP") {
+        spawnWave();
+      }
     };
     const onMouseDown = (event: MouseEvent) => {
       if (event.button === 0) {
@@ -201,6 +217,7 @@ export function GameCanvas({ className, onHudUpdate }: Props) {
       for (const dummy of dummies) {
         dummy.update(combatResolver, deltaSeconds);
       }
+      enemySystem.update(deltaSeconds);
       if (hudCallbackRef.current) {
         hudTimer += deltaSeconds;
         if (hudTimer >= 0.1) {
@@ -230,6 +247,7 @@ export function GameCanvas({ className, onHudUpdate }: Props) {
       window.removeEventListener("resize", onResize);
       window.removeEventListener("keydown", onKeyDown);
       window.removeEventListener("mousedown", onMouseDown);
+      enemySystem.clear();
       movementSystem.dispose();
       cameraSystem.dispose();
       scene.dispose();

--- a/apps/web/src/game/entities/enemies/EnemyBase.ts
+++ b/apps/web/src/game/entities/enemies/EnemyBase.ts
@@ -1,0 +1,219 @@
+import type { Scene } from "@babylonjs/core/scene";
+import { MeshBuilder } from "@babylonjs/core/Meshes/meshBuilder";
+import type { AbstractMesh } from "@babylonjs/core/Meshes/abstractMesh";
+import { StandardMaterial } from "@babylonjs/core/Materials/standardMaterial";
+import { Color3 } from "@babylonjs/core/Maths/math.color";
+import { Vector3 } from "@babylonjs/core/Maths/math.vector";
+import type { Combatant, StaggerComponent } from "../../combat/CombatTypes";
+import type { EnemyConfig, EnemyModifier } from "./EnemyTypes";
+import type { CombatResolver } from "../../combat/CombatResolver";
+
+type EnemyState = "idle" | "chase" | "windup" | "recover";
+
+export class EnemyBase {
+  private readonly scene: Scene;
+  private readonly config: EnemyConfig;
+  private readonly mesh: AbstractMesh;
+  private readonly material: StandardMaterial;
+  private readonly combatant: Combatant;
+  private readonly stagger: StaggerComponent;
+  private readonly id: string;
+  private readonly modifiers: Set<EnemyModifier>;
+  private readonly baseColor: Color3;
+  private readonly hitColor = new Color3(1, 0.4, 0.4);
+  private readonly staggerColor = new Color3(1, 0.8, 0.2);
+  private readonly deadColor = new Color3(0.2, 0.2, 0.2);
+  private readonly black = Color3.Black();
+  private readonly toTarget = new Vector3();
+  private readonly moveDelta = new Vector3();
+  private readonly baseScaling = new Vector3(1, 1, 1);
+
+  private hitFlashTimer = 0;
+  private attackCooldownTimer = 0;
+  private state: EnemyState = "idle";
+  private stateTimer = 0;
+  private adaptiveHits = 0;
+  private isDead = false;
+  private onDeath?: (enemy: EnemyBase) => void;
+
+  constructor(scene: Scene, resolver: CombatResolver, config: EnemyConfig, position: Vector3, modifiers: EnemyModifier[] = []) {
+    this.scene = scene;
+    this.config = config;
+    this.id = `${config.archetype}_${Math.floor(Math.random() * 9999)}`;
+    this.modifiers = new Set(modifiers);
+    this.baseColor = config.color;
+
+    const sizeScale = config.archetype === "bruiser" ? 1.4 : config.archetype === "controller" ? 1.1 : 1.0;
+    this.mesh = MeshBuilder.CreateCapsule(
+      `enemy_${this.id}`,
+      { height: 2.1 * sizeScale, radius: 0.45 * sizeScale },
+      scene
+    );
+    this.mesh.position.copyFrom(position);
+    this.mesh.checkCollisions = true;
+    this.mesh.isPickable = true;
+    this.baseScaling.copyFrom(this.mesh.scaling);
+
+    this.material = new StandardMaterial(`enemy_mat_${this.id}`, scene);
+    this.material.diffuseColor = this.baseColor.clone();
+    this.material.emissiveColor = this.black.clone();
+    this.mesh.material = this.material;
+
+    this.stagger = {
+      staggerThreshold: config.staggerThreshold,
+      staggerValue: 0,
+      isStaggered: false,
+      staggerDuration: 0.5,
+      staggerTimer: 0,
+      cooldown: 0.3,
+      cooldownTimer: 0,
+    };
+
+    if (this.modifiers.has("hardened")) {
+      this.stagger.staggerThreshold *= 1.6;
+    }
+
+    this.combatant = {
+      id: this.id,
+      health: { maxHealth: config.maxHealth, currentHealth: config.maxHealth },
+      stagger: this.stagger,
+      isDead: false,
+      setDead: () => {
+        this.isDead = true;
+        this.mesh.isPickable = false;
+        this.mesh.checkCollisions = false;
+        this.material.diffuseColor.copyFrom(this.deadColor);
+        this.material.emissiveColor.copyFrom(this.black);
+        this.mesh.scaling.y = 0.3;
+        this.combatant.isDead = true;
+        this.onDeath?.(this);
+      },
+      getPosition: () => this.mesh.position,
+      getForward: () => this.mesh.forward,
+    };
+
+    resolver.events.onHit((event, target) => {
+      if (target.id !== this.combatant.id) return;
+      this.hitFlashTimer = 0.12;
+      if (!this.stagger.isStaggered) {
+        this.material.emissiveColor.copyFrom(this.hitColor);
+      }
+      if (event.sourceId === "player_1" && this.modifiers.has("adaptive")) {
+        this.adaptiveHits += 1;
+      }
+    });
+
+    resolver.events.onStagger((target) => {
+      if (target.id !== this.combatant.id) return;
+      this.material.emissiveColor.copyFrom(this.staggerColor);
+    });
+  }
+
+  getCombatant(): Combatant {
+    return this.combatant;
+  }
+
+  getMesh(): AbstractMesh {
+    return this.mesh;
+  }
+
+  getMaterial(): StandardMaterial {
+    return this.material;
+  }
+
+  getConfig(): EnemyConfig {
+    return this.config;
+  }
+
+  getState(): EnemyState {
+    return this.state;
+  }
+
+  setState(state: EnemyState, timer = 0): void {
+    this.state = state;
+    this.stateTimer = timer;
+  }
+
+  getStateTimer(): number {
+    return this.stateTimer;
+  }
+
+  getCooldownTimer(): number {
+    return this.attackCooldownTimer;
+  }
+
+  setCooldownTimer(value: number): void {
+    this.attackCooldownTimer = value;
+  }
+
+  setOnDeath(callback: (enemy: EnemyBase) => void): void {
+    this.onDeath = callback;
+  }
+
+  isStaggered(): boolean {
+    return this.stagger.isStaggered;
+  }
+
+  isAlive(): boolean {
+    return !this.isDead;
+  }
+
+  getModifiers(): Set<EnemyModifier> {
+    return this.modifiers;
+  }
+
+  getAdaptiveHits(): number {
+    return this.adaptiveHits;
+  }
+
+  resetAdaptiveHits(): void {
+    this.adaptiveHits = 0;
+  }
+
+  updateVisual(deltaSeconds: number): void {
+    if (this.isDead) return;
+
+    if (this.stagger.isStaggered) {
+      this.material.emissiveColor.copyFrom(this.staggerColor);
+    }
+
+    if (this.hitFlashTimer > 0) {
+      this.hitFlashTimer = Math.max(0, this.hitFlashTimer - deltaSeconds);
+    }
+
+    if (this.state !== "windup" && !this.stagger.isStaggered && this.hitFlashTimer === 0) {
+      this.material.emissiveColor.copyFrom(this.black);
+    }
+  }
+
+  setEmissive(color: Color3): void {
+    this.material.emissiveColor.copyFrom(color);
+  }
+
+  setScale(multiplier: number): void {
+    this.mesh.scaling.x = this.baseScaling.x * multiplier;
+    this.mesh.scaling.y = this.baseScaling.y * multiplier;
+    this.mesh.scaling.z = this.baseScaling.z * multiplier;
+  }
+
+  updateMovement(deltaSeconds: number, targetPosition: Vector3): void {
+    if (this.isDead) return;
+    if (this.stagger.isStaggered) return;
+    if (this.state !== "chase") return;
+
+    this.toTarget.copyFrom(targetPosition).subtractInPlace(this.mesh.position);
+    this.toTarget.y = 0;
+    const distance = this.toTarget.length();
+    if (distance < 0.001) return;
+    this.toTarget.scaleInPlace(1 / distance);
+    this.moveDelta.copyFrom(this.toTarget).scaleInPlace(this.config.speed * deltaSeconds);
+    this.mesh.moveWithCollisions(this.moveDelta);
+    this.mesh.rotation.y = Math.atan2(this.toTarget.x, this.toTarget.z);
+  }
+
+  updateState(deltaSeconds: number): void {
+    if (this.stateTimer > 0) {
+      this.stateTimer = Math.max(0, this.stateTimer - deltaSeconds);
+    }
+  }
+}

--- a/apps/web/src/game/entities/enemies/EnemyConfigs.ts
+++ b/apps/web/src/game/entities/enemies/EnemyConfigs.ts
@@ -1,0 +1,49 @@
+import { Color3 } from "@babylonjs/core/Maths/math.color";
+import type { EnemyConfig } from "./EnemyTypes";
+
+export const gruntConfig: EnemyConfig = {
+  archetype: "grunt",
+  maxHealth: 40,
+  staggerThreshold: 16,
+  speed: 3.2,
+  attackRange: 1.6,
+  attackCooldown: 1.0,
+  attackWindup: 0.15,
+  attackRecover: 0.3,
+  damage: 6,
+  stagger: 4,
+  color: new Color3(0.7, 0.2, 0.2),
+  attackType: "melee",
+};
+
+export const bruiserConfig: EnemyConfig = {
+  archetype: "bruiser",
+  maxHealth: 120,
+  staggerThreshold: 40,
+  speed: 2.1,
+  attackRange: 2.2,
+  attackCooldown: 2.2,
+  attackWindup: 0.6,
+  attackRecover: 0.6,
+  damage: 16,
+  stagger: 16,
+  color: new Color3(0.5, 0.1, 0.1),
+  attackType: "melee",
+};
+
+export const controllerConfig: EnemyConfig = {
+  archetype: "controller",
+  maxHealth: 60,
+  staggerThreshold: 22,
+  speed: 2.6,
+  attackRange: 8,
+  attackCooldown: 2.6,
+  attackWindup: 0.3,
+  attackRecover: 0.4,
+  damage: 4,
+  stagger: 6,
+  color: new Color3(0.2, 0.6, 0.8),
+  attackType: "pulse",
+  slowMultiplier: 0.7,
+  slowDuration: 1.6,
+};

--- a/apps/web/src/game/entities/enemies/EnemyTypes.ts
+++ b/apps/web/src/game/entities/enemies/EnemyTypes.ts
@@ -1,0 +1,22 @@
+import type { Color3 } from "@babylonjs/core/Maths/math.color";
+
+export type EnemyArchetype = "grunt" | "bruiser" | "controller";
+
+export type EnemyModifier = "hardened" | "volatile" | "adaptive";
+
+export type EnemyConfig = {
+  archetype: EnemyArchetype;
+  maxHealth: number;
+  staggerThreshold: number;
+  speed: number;
+  attackRange: number;
+  attackCooldown: number;
+  attackWindup: number;
+  attackRecover: number;
+  damage: number;
+  stagger: number;
+  color: Color3;
+  attackType: "melee" | "pulse";
+  slowMultiplier?: number;
+  slowDuration?: number;
+};

--- a/apps/web/src/game/systems/EnemyAISystem.ts
+++ b/apps/web/src/game/systems/EnemyAISystem.ts
@@ -1,0 +1,217 @@
+import type { Scene } from "@babylonjs/core/scene";
+import { Vector3 } from "@babylonjs/core/Maths/math.vector";
+import { MeshBuilder } from "@babylonjs/core/Meshes/meshBuilder";
+import { StandardMaterial } from "@babylonjs/core/Materials/standardMaterial";
+import { Color3 } from "@babylonjs/core/Maths/math.color";
+import type { CombatResolver } from "../combat/CombatResolver";
+import type { Combatant, DamageEvent } from "../combat/CombatTypes";
+import type { PlayerMovementSystem } from "./PlayerMovementSystem";
+import { EnemyBase } from "../entities/enemies/EnemyBase";
+import type { EnemyConfig, EnemyModifier } from "../entities/enemies/EnemyTypes";
+import type { AbstractMesh } from "@babylonjs/core/Meshes/abstractMesh";
+
+type Vfx = { mesh: AbstractMesh; remaining: number };
+
+export class EnemyAISystem {
+  private readonly scene: Scene;
+  private readonly resolver: CombatResolver;
+  private readonly player: Combatant;
+  private readonly playerMovement: PlayerMovementSystem;
+  private readonly enemies: EnemyBase[] = [];
+  private readonly vfx: Vfx[] = [];
+  private readonly tempTarget = new Vector3();
+  private readonly playerPosition = new Vector3();
+  private readonly toPlayer = new Vector3();
+  private readonly pulseMaterial: StandardMaterial;
+  private readonly windupMaterial: StandardMaterial;
+  private readonly black = Color3.Black();
+
+  constructor(scene: Scene, resolver: CombatResolver, player: Combatant, playerMovement: PlayerMovementSystem) {
+    this.scene = scene;
+    this.resolver = resolver;
+    this.player = player;
+    this.playerMovement = playerMovement;
+
+    this.pulseMaterial = new StandardMaterial("controller_pulse_mat", scene);
+    this.pulseMaterial.diffuseColor = new Color3(0.2, 0.9, 1);
+    this.pulseMaterial.emissiveColor = new Color3(0.2, 0.9, 1);
+
+    this.windupMaterial = new StandardMaterial("bruiser_windup_mat", scene);
+    this.windupMaterial.diffuseColor = new Color3(1, 0.5, 0.2);
+    this.windupMaterial.emissiveColor = new Color3(1, 0.5, 0.2);
+  }
+
+  spawnEnemy(config: EnemyConfig, position: Vector3, modifiers: EnemyModifier[] = []): EnemyBase {
+    const enemy = new EnemyBase(this.scene, this.resolver, config, position, modifiers);
+    enemy.setOnDeath((dead) => {
+      if (dead.getModifiers().has("volatile")) {
+        this.spawnExplosion(dead.getMesh().position.clone());
+        const distance = Vector3.Distance(dead.getMesh().position, this.player.getPosition?.() ?? Vector3.Zero());
+        if (distance <= 3.5) {
+          const event: DamageEvent = {
+            amount: 10,
+            type: "energy",
+            sourceId: dead.getCombatant().id,
+            targetId: this.player.id,
+            hitPoint: null,
+            timestamp: performance.now(),
+            staggerAmount: 8,
+            sourcePosition: dead.getMesh().position,
+          };
+          this.resolver.applyDamage(this.player, event);
+        }
+      }
+    });
+    this.enemies.push(enemy);
+    return enemy;
+  }
+
+  clear(): void {
+    for (const enemy of this.enemies) {
+      enemy.getMesh().dispose();
+    }
+    this.enemies.length = 0;
+    for (const fx of this.vfx) {
+      fx.mesh.dispose();
+    }
+    this.vfx.length = 0;
+  }
+
+  update(deltaSeconds: number): void {
+    if (this.player.getPosition) {
+      this.playerPosition.copyFrom(this.player.getPosition());
+    } else {
+      return;
+    }
+
+    for (const enemy of this.enemies) {
+      if (!enemy.isAlive()) continue;
+      this.resolver.updateStagger(enemy.getCombatant().stagger!, deltaSeconds);
+      enemy.updateVisual(deltaSeconds);
+      enemy.updateState(deltaSeconds);
+      this.updateEnemyAI(enemy, deltaSeconds);
+      enemy.updateMovement(deltaSeconds, this.playerPosition);
+    }
+
+    for (let i = this.vfx.length - 1; i >= 0; i -= 1) {
+      this.vfx[i].remaining -= deltaSeconds;
+      if (this.vfx[i].remaining <= 0) {
+        this.vfx[i].mesh.dispose();
+        this.vfx.splice(i, 1);
+      }
+    }
+  }
+
+  private updateEnemyAI(enemy: EnemyBase, deltaSeconds: number): void {
+    const config = enemy.getConfig();
+    this.toPlayer.copyFrom(this.playerPosition).subtractInPlace(enemy.getMesh().position);
+    const distance = this.toPlayer.length();
+    const inRange = distance <= config.attackRange;
+
+    if (enemy.isStaggered()) {
+      enemy.setState("recover", 0.2);
+      enemy.setScale(1);
+      return;
+    }
+
+    const cooldown = enemy.getCooldownTimer();
+    if (cooldown > 0) {
+      enemy.setCooldownTimer(Math.max(0, cooldown - deltaSeconds));
+    }
+
+    if (enemy.getState() === "windup") {
+      if (enemy.getStateTimer() === 0) {
+        if (inRange) {
+          this.performAttack(enemy);
+        }
+        enemy.setEmissive(this.black);
+        enemy.setScale(1);
+        enemy.setState("recover", config.attackRecover);
+      }
+      return;
+    }
+
+    if (enemy.getState() === "recover") {
+      if (enemy.getStateTimer() === 0) {
+        enemy.setState("chase");
+      }
+      return;
+    }
+
+    if (!inRange) {
+      enemy.setState("chase");
+      return;
+    }
+
+    if (cooldown === 0) {
+      enemy.setCooldownTimer(config.attackCooldown * this.getAdaptiveCooldownScale(enemy));
+      enemy.setState("windup", config.attackWindup);
+      if (config.archetype === "bruiser") {
+        enemy.setEmissive(this.windupMaterial.emissiveColor);
+        enemy.setScale(1.12);
+      }
+      return;
+    }
+
+    enemy.setState("chase");
+  }
+
+  private performAttack(enemy: EnemyBase): void {
+    const config = enemy.getConfig();
+
+    if (config.attackType === "pulse") {
+      this.spawnPulse(enemy.getMesh().position.clone(), config.attackRange);
+      if (config.slowMultiplier && config.slowDuration) {
+        this.playerMovement.applySlow(config.slowMultiplier, config.slowDuration);
+      }
+    }
+
+    const event: DamageEvent = {
+      amount: config.damage,
+      type: config.attackType === "pulse" ? "energy" : "physical",
+      sourceId: enemy.getCombatant().id,
+      targetId: this.player.id,
+      hitPoint: null,
+      timestamp: performance.now(),
+      staggerAmount: config.stagger,
+      sourcePosition: enemy.getMesh().position,
+    };
+    this.resolver.applyDamage(this.player, event);
+
+    if (config.archetype === "bruiser") {
+      const mesh = enemy.getMesh();
+      mesh.scaling.y *= 1.05;
+    }
+  }
+
+  private getAdaptiveCooldownScale(enemy: EnemyBase): number {
+    if (!enemy.getModifiers().has("adaptive")) return 1;
+    if (enemy.getAdaptiveHits() >= 3) {
+      enemy.resetAdaptiveHits();
+      return 0.8;
+    }
+    return 1;
+  }
+
+  private spawnPulse(position: Vector3, radius: number): void {
+    const ring = MeshBuilder.CreateTorus("controller_pulse", { diameter: radius * 2, thickness: 0.1 }, this.scene);
+    ring.position.copyFrom(position);
+    ring.position.y = 0.2;
+    ring.rotation.x = Math.PI / 2;
+    ring.material = this.pulseMaterial;
+    ring.isPickable = false;
+    this.vfx.push({ mesh: ring, remaining: 0.4 });
+  }
+
+  private spawnExplosion(position: Vector3): void {
+    const sphere = MeshBuilder.CreateSphere("volatile_explosion", { diameter: 2.5 }, this.scene);
+    sphere.position.copyFrom(position);
+    sphere.position.y = 0.8;
+    const mat = new StandardMaterial("volatile_explosion_mat", this.scene);
+    mat.diffuseColor = new Color3(1, 0.3, 0.1);
+    mat.emissiveColor = new Color3(1, 0.3, 0.1);
+    sphere.material = mat;
+    sphere.isPickable = false;
+    this.vfx.push({ mesh: sphere, remaining: 0.3 });
+  }
+}


### PR DESCRIPTION
Summary:\n- add enemy archetype configs (grunt/bruiser/controller) with distinct stats\n- add EnemyBase entity and simple AI system (idle/chase/windup/recover)\n- add elite modifiers (hardened, volatile, adaptive) and test wave spawner\n- add controller slow debuff and volatile death burst\n\nManual Test Plan:\n- cd apps/web && npm run lint\n- cd apps/web && npm run test\n- cd apps/web && npm run build (note: build may take >3 min in this env)\n- Run dev server and verify:\n  - Press P to respawn the test wave (3 grunts, 1 bruiser, 1 controller)\n  - Grunts: small red capsules, faster attack cadence\n  - Bruiser: larger mesh, slow wind-up, heavy hit + strong stagger\n  - Controller: blue-ish mesh; ranged pulse + slow debuff (movement feels reduced)\n  - Hardened grunt takes more hits to stagger\n  - Volatile bruiser explodes on death and damages player nearby\n  - Adaptive controller ramps attack cadence slightly after multiple hits\n  - Enemies stop moving/attacking when dead or staggered\n\nKeybind notes:\n- P respawns enemy wave\n\nCloses #7