### PR TITLE
Mission framework and objectives

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -1,5 +1,7 @@
-import React, { useState } from "react";
+import React, { useMemo, useState } from "react";
 import { GameCanvas } from "./game/core/GameCanvas";
+import { missionRegistry } from "./game/missions/MissionRegistry";
+import type { MissionHudState } from "./game/missions/MissionTypes";
 
 type HudState = {
   heroName: string;
@@ -15,6 +17,10 @@ type HudState = {
 export default function App() {
   const [playing, setPlaying] = useState(false);
   const [hud, setHud] = useState<HudState | null>(null);
+  const [missionHud, setMissionHud] = useState<MissionHudState | null>(null);
+  const [missionId, setMissionId] = useState<string>(missionRegistry[0]?.id ?? "");
+  const [missionRunId, setMissionRunId] = useState(0);
+  const missions = useMemo(() => missionRegistry, []);
 
   if (!playing) {
     return (
@@ -22,6 +28,18 @@ export default function App() {
         <div className="max-w-md w-full p-6 rounded-2xl shadow">
           <h1 className="text-2xl font-semibold mb-2">Fracture: Ascension</h1>
           <p className="opacity-80 mb-6">Single-player story prototype (Babylon.js + React)</p>
+          <label className="block text-sm mb-2">Mission</label>
+          <select
+            className="w-full border rounded-lg px-2 py-1 mb-4"
+            value={missionId}
+            onChange={(event) => setMissionId(event.target.value)}
+          >
+            {missions.map((mission) => (
+              <option key={mission.id} value={mission.id}>
+                {mission.name}
+              </option>
+            ))}
+          </select>
           <button
             className="px-4 py-2 rounded-xl border"
             onClick={() => setPlaying(true)}
@@ -35,7 +53,12 @@ export default function App() {
 
   return (
     <div className="h-full relative">
-      <GameCanvas onHudUpdate={setHud} />
+      <GameCanvas
+        onHudUpdate={setHud}
+        onMissionUpdate={setMissionHud}
+        missionId={missionId}
+        missionRunId={missionRunId}
+      />
       <button
         className="absolute top-4 left-4 px-3 py-2 rounded-xl border bg-white/80"
         onClick={() => setPlaying(false)}
@@ -52,6 +75,37 @@ export default function App() {
           <div>E: {hud.cooldowns.ability2.toFixed(1)}s</div>
           <div>R: {hud.cooldowns.ability3.toFixed(1)}s</div>
           <div>T: {hud.ultimateReady ? "ULT READY" : `${Math.round(hud.ultimateCharge * 100)}%`}</div>
+        </div>
+      )}
+      {missionHud && (
+        <div className="absolute bottom-4 left-4 w-80 rounded-xl border bg-white/80 p-3 text-sm">
+          <div className="font-semibold">{missionHud.name}</div>
+          <div className="opacity-70">Phase: {missionHud.phase}</div>
+          <div className="mt-2 space-y-1">
+            {missionHud.objectives.map((objective) => (
+              <div key={objective.id}>
+                <span>
+                  {objective.status === "completed" ? "[x]" : objective.status === "failed" ? "[!]" : "[ ]"}
+                </span>{" "}
+                {objective.title}
+                {objective.optional ? " (Optional)" : ""} — {objective.statusText}
+              </div>
+            ))}
+          </div>
+          <div className="mt-2">
+            Optional: {missionHud.optionalCompleted}/{missionHud.optionalTotal}
+          </div>
+          {(missionHud.phase === "completed" || missionHud.phase === "failed") && (
+            <div className="mt-3">
+              <div className="font-semibold">{missionHud.resultText}</div>
+              <button
+                className="mt-2 px-3 py-1 rounded-lg border"
+                onClick={() => setMissionRunId((value) => value + 1)}
+              >
+                Restart Mission
+              </button>
+            </div>
+          )}
         </div>
       )}
     </div>

--- a/apps/web/src/game/missions/MissionEvents.ts
+++ b/apps/web/src/game/missions/MissionEvents.ts
@@ -1,0 +1,43 @@
+import type { MissionPhase, MissionObjective } from "./MissionTypes";
+
+type PhaseListener = (phase: MissionPhase) => void;
+type ObjectiveListener = (objective: MissionObjective) => void;
+
+export class MissionEvents {
+  private readonly phaseListeners = new Set<PhaseListener>();
+  private readonly objectiveCompleted = new Set<ObjectiveListener>();
+  private readonly objectiveFailed = new Set<ObjectiveListener>();
+
+  onPhaseChanged(listener: PhaseListener): () => void {
+    this.phaseListeners.add(listener);
+    return () => this.phaseListeners.delete(listener);
+  }
+
+  onObjectiveCompleted(listener: ObjectiveListener): () => void {
+    this.objectiveCompleted.add(listener);
+    return () => this.objectiveCompleted.delete(listener);
+  }
+
+  onObjectiveFailed(listener: ObjectiveListener): () => void {
+    this.objectiveFailed.add(listener);
+    return () => this.objectiveFailed.delete(listener);
+  }
+
+  emitPhaseChanged(phase: MissionPhase): void {
+    for (const listener of this.phaseListeners) {
+      listener(phase);
+    }
+  }
+
+  emitObjectiveCompleted(objective: MissionObjective): void {
+    for (const listener of this.objectiveCompleted) {
+      listener(objective);
+    }
+  }
+
+  emitObjectiveFailed(objective: MissionObjective): void {
+    for (const listener of this.objectiveFailed) {
+      listener(objective);
+    }
+  }
+}

--- a/apps/web/src/game/missions/MissionRegistry.ts
+++ b/apps/web/src/game/missions/MissionRegistry.ts
@@ -1,0 +1,69 @@
+import { Vector3 } from "@babylonjs/core/Maths/math.vector";
+import { DefeatEnemiesObjective } from "./objectives/DefeatEnemiesObjective";
+import { HoldAreaObjective } from "./objectives/HoldAreaObjective";
+import { DisableDeviceObjective } from "./objectives/DisableDeviceObjective";
+import { TimeLimitObjective } from "./objectives/TimeLimitObjective";
+import { DamageTakenObjective } from "./objectives/DamageTakenObjective";
+import type { MissionDefinition, MissionInstance, MissionContext } from "./MissionTypes";
+
+const setupContainmentSweep = (context: MissionContext): MissionInstance => {
+  context.clearEnemies();
+  context.clearDevices();
+  context.clearAreaMarkers();
+  context.spawnEnemies("grunt", 3);
+  context.spawnEnemies("bruiser", 1, ["hardened"]);
+  const objectives = [
+    new DefeatEnemiesObjective("defeat_wave", "Defeat all hostiles", 4),
+    new TimeLimitObjective("time_limit", "Finish within time", 45, true),
+  ];
+  return {
+    objectives,
+    cleanup: () => {
+      context.clearEnemies();
+      context.clearDevices();
+      context.clearAreaMarkers();
+    },
+  };
+};
+
+const setupDisableRelay = (context: MissionContext): MissionInstance => {
+  context.clearEnemies();
+  context.clearDevices();
+  context.clearAreaMarkers();
+  context.spawnEnemies("grunt", 2);
+  context.spawnEnemies("controller", 1, ["adaptive"]);
+
+  const deviceA = context.spawnDevice(new Vector3(6, 0.8, 6), 2, "relay_a");
+  const deviceB = context.spawnDevice(new Vector3(-6, 0.8, -4), 2, "relay_b");
+  context.spawnAreaMarker(new Vector3(0, 0, 10), 4.5, "relay_zone");
+
+  const objectives = [
+    new DisableDeviceObjective("disable_relays", "Disable relay devices", [deviceA, deviceB]),
+    new HoldAreaObjective("hold_zone", "Hold the relay zone", new Vector3(0, 0, 10), 4.5, 20),
+    new DamageTakenObjective("avoid_damage", "Take minimal damage", 30, true),
+  ];
+
+  return {
+    objectives,
+    cleanup: () => {
+      context.clearEnemies();
+      context.clearDevices();
+      context.clearAreaMarkers();
+    },
+  };
+};
+
+export const missionRegistry: MissionDefinition[] = [
+  {
+    id: "containment_sweep",
+    name: "Containment Sweep",
+    description: "Clear the hostiles in the district.",
+    setup: setupContainmentSweep,
+  },
+  {
+    id: "disable_relay",
+    name: "Disable the Relay",
+    description: "Shut down relay devices and hold the area.",
+    setup: setupDisableRelay,
+  },
+];

--- a/apps/web/src/game/missions/MissionRunner.ts
+++ b/apps/web/src/game/missions/MissionRunner.ts
@@ -1,0 +1,130 @@
+import type {
+  MissionContext,
+  MissionDefinition,
+  MissionHudState,
+  MissionInstance,
+  MissionObjective,
+  MissionPhase,
+  ObjectiveView,
+} from "./MissionTypes";
+import { MissionEvents } from "./MissionEvents";
+
+export class MissionRunner {
+  private readonly context: MissionContext;
+  private readonly registry: MissionDefinition[];
+  private currentMission: MissionDefinition | null = null;
+  private currentInstance: MissionInstance | null = null;
+  private objectives: MissionObjective[] = [];
+  private phase: MissionPhase = "briefing";
+  private resultText: string | undefined;
+  readonly events = new MissionEvents();
+
+  constructor(context: MissionContext, registry: MissionDefinition[]) {
+    this.context = context;
+    this.registry = registry;
+  }
+
+  startMission(id: string): void {
+    const mission = this.registry.find((entry) => entry.id === id);
+    if (!mission) return;
+
+    this.currentInstance?.cleanup();
+    this.currentMission = mission;
+    this.phase = "briefing";
+    this.events.emitPhaseChanged(this.phase);
+    this.context.clearEnemies();
+    this.context.clearDevices();
+    this.context.clearAreaMarkers();
+    this.context.playerHealth.current = this.context.playerHealth.max;
+
+    this.currentInstance = mission.setup(this.context);
+    this.objectives = this.currentInstance.objectives;
+    for (const objective of this.objectives) {
+      objective.start();
+    }
+    this.phase = "inProgress";
+    this.events.emitPhaseChanged(this.phase);
+    this.resultText = undefined;
+  }
+
+  update(deltaSeconds: number): void {
+    if (!this.currentMission) return;
+    if (this.phase !== "inProgress") return;
+
+    const playerDead = this.context.playerHealth.current <= 0;
+    if (playerDead) {
+      this.failMission("Mission Failed: Player Down");
+      return;
+    }
+
+    for (const objective of this.objectives) {
+      if (objective.status === "completed" || objective.status === "failed") continue;
+      objective.update(deltaSeconds, this.context);
+      if (objective.status === "completed") {
+        this.events.emitObjectiveCompleted(objective);
+      }
+      if (objective.status === "failed") {
+        this.events.emitObjectiveFailed(objective);
+      }
+    }
+
+    const requiredObjectives = this.objectives.filter((obj) => !obj.optional);
+    const requiredFailed = requiredObjectives.some((obj) => obj.status === "failed");
+    if (requiredFailed) {
+      this.failMission("Mission Failed");
+      return;
+    }
+
+    const requiredComplete = requiredObjectives.every((obj) => obj.status === "completed");
+    if (requiredComplete) {
+      this.completeMission("Mission Complete");
+    }
+  }
+
+  getPhase(): MissionPhase {
+    return this.phase;
+  }
+
+  setInteractPressed(value: boolean): void {
+    this.context.input.interactPressed = value;
+  }
+
+  consumeInteract(): void {
+    this.context.input.interactPressed = false;
+  }
+
+  getHudState(): MissionHudState | null {
+    if (!this.currentMission) return null;
+    const objectiveViews: ObjectiveView[] = this.objectives.map((objective) => ({
+      id: objective.id,
+      title: objective.title,
+      optional: objective.optional,
+      status: objective.status,
+      progress: objective.progress,
+      statusText: objective.getStatusText(),
+    }));
+    const optionalObjectives = this.objectives.filter((obj) => obj.optional);
+    const optionalCompleted = optionalObjectives.filter((obj) => obj.status === "completed").length;
+    return {
+      id: this.currentMission.id,
+      name: this.currentMission.name,
+      phase: this.phase,
+      objectives: objectiveViews,
+      optionalCompleted,
+      optionalTotal: optionalObjectives.length,
+      resultText: this.resultText,
+    };
+  }
+
+  private completeMission(text: string): void {
+    this.phase = "completed";
+    this.resultText = text;
+    this.events.emitPhaseChanged(this.phase);
+  }
+
+  private failMission(text: string): void {
+    this.phase = "failed";
+    this.resultText = text;
+    this.events.emitPhaseChanged(this.phase);
+  }
+}

--- a/apps/web/src/game/missions/MissionTypes.ts
+++ b/apps/web/src/game/missions/MissionTypes.ts
@@ -1,0 +1,76 @@
+import type { Vector3 } from "@babylonjs/core/Maths/math.vector";
+
+export type MissionPhase = "briefing" | "inProgress" | "completed" | "failed";
+
+export type ObjectiveStatus = "notStarted" | "active" | "completed" | "failed";
+
+export type ObjectiveView = {
+  id: string;
+  title: string;
+  optional: boolean;
+  status: ObjectiveStatus;
+  progress: number;
+  statusText: string;
+};
+
+export type MissionHudState = {
+  id: string;
+  name: string;
+  phase: MissionPhase;
+  objectives: ObjectiveView[];
+  optionalCompleted: number;
+  optionalTotal: number;
+  resultText?: string;
+};
+
+export type MissionObjective = {
+  id: string;
+  title: string;
+  optional: boolean;
+  status: ObjectiveStatus;
+  progress: number;
+  start: () => void;
+  update: (deltaSeconds: number, context: MissionContext) => void;
+  getStatusText: () => string;
+};
+
+export type MissionDefinition = {
+  id: string;
+  name: string;
+  description: string;
+  setup: (context: MissionContext) => MissionInstance;
+};
+
+export type MissionInstance = {
+  objectives: MissionObjective[];
+  cleanup: () => void;
+};
+
+export type MissionContext = {
+  scene: unknown;
+  playerPosition: Vector3;
+  playerHealth: { max: number; current: number };
+  input: {
+    interactPressed: boolean;
+  };
+  spawnDevice: (position: Vector3, radius: number, id: string) => MissionDevice;
+  clearDevices: () => void;
+  spawnAreaMarker: (position: Vector3, radius: number, id: string) => void;
+  clearAreaMarkers: () => void;
+  spawnEnemies: (archetype: "grunt" | "bruiser" | "controller", count: number, modifiers?: string[]) => void;
+  getActiveEnemies: () => MissionEnemyRef[];
+  clearEnemies: () => void;
+};
+
+export type MissionDevice = {
+  id: string;
+  position: Vector3;
+  radius: number;
+  isDisabled: boolean;
+  disable: () => void;
+};
+
+export type MissionEnemyRef = {
+  id: string;
+  isAlive: () => boolean;
+};

--- a/apps/web/src/game/missions/objectives/DamageTakenObjective.ts
+++ b/apps/web/src/game/missions/objectives/DamageTakenObjective.ts
@@ -1,0 +1,38 @@
+import type { MissionContext, MissionObjective } from "../MissionTypes";
+
+export class DamageTakenObjective implements MissionObjective {
+  id: string;
+  title: string;
+  optional: boolean;
+  status: MissionObjective["status"] = "notStarted";
+  progress = 1;
+  private readonly maxDamage: number;
+  private baselineHealth = 0;
+
+  constructor(id: string, title: string, maxDamage: number, optional = true) {
+    this.id = id;
+    this.title = title;
+    this.optional = optional;
+    this.maxDamage = maxDamage;
+  }
+
+  start(): void {
+    this.status = "active";
+  }
+
+  update(_deltaSeconds: number, context: MissionContext): void {
+    if (this.status !== "active") return;
+    if (this.baselineHealth === 0) {
+      this.baselineHealth = context.playerHealth.current;
+    }
+    const damageTaken = Math.max(0, this.baselineHealth - context.playerHealth.current);
+    this.progress = this.maxDamage === 0 ? 1 : Math.max(0, 1 - damageTaken / this.maxDamage);
+    if (damageTaken > this.maxDamage) {
+      this.status = "failed";
+    }
+  }
+
+  getStatusText(): string {
+    return `${this.title}`;
+  }
+}

--- a/apps/web/src/game/missions/objectives/DefeatEnemiesObjective.ts
+++ b/apps/web/src/game/missions/objectives/DefeatEnemiesObjective.ts
@@ -1,0 +1,40 @@
+import type { MissionContext, MissionObjective } from "../MissionTypes";
+
+export class DefeatEnemiesObjective implements MissionObjective {
+  id: string;
+  title: string;
+  optional: boolean;
+  status: MissionObjective["status"] = "notStarted";
+  progress = 0;
+  private readonly targetCount: number;
+  private readonly label: string;
+
+  constructor(id: string, title: string, targetCount: number, optional = false) {
+    this.id = id;
+    this.title = title;
+    this.optional = optional;
+    this.targetCount = targetCount;
+    this.label = title;
+  }
+
+  start(): void {
+    this.status = "active";
+  }
+
+  update(_deltaSeconds: number, context: MissionContext): void {
+    if (this.status !== "active") return;
+    const enemies = context.getActiveEnemies();
+    const total = enemies.length > 0 ? Math.min(this.targetCount, enemies.length) : this.targetCount;
+    const defeated = enemies.filter((enemy) => !enemy.isAlive()).length;
+    this.progress = total === 0 ? 1 : Math.min(1, defeated / total);
+    if (defeated >= total && total > 0) {
+      this.status = "completed";
+    }
+  }
+
+  getStatusText(): string {
+    const enemies = this.targetCount;
+    const defeated = Math.round(this.progress * enemies);
+    return `${this.label} (${defeated}/${enemies})`;
+  }
+}

--- a/apps/web/src/game/missions/objectives/DisableDeviceObjective.ts
+++ b/apps/web/src/game/missions/objectives/DisableDeviceObjective.ts
@@ -1,0 +1,49 @@
+import type { MissionContext, MissionDevice, MissionObjective } from "../MissionTypes";
+import { Vector3 } from "@babylonjs/core/Maths/math.vector";
+
+export class DisableDeviceObjective implements MissionObjective {
+  id: string;
+  title: string;
+  optional: boolean;
+  status: MissionObjective["status"] = "notStarted";
+  progress = 0;
+  private readonly devices: MissionDevice[];
+  private readonly label: string;
+
+  constructor(id: string, title: string, devices: MissionDevice[], optional = false) {
+    this.id = id;
+    this.title = title;
+    this.optional = optional;
+    this.devices = devices;
+    this.label = title;
+  }
+
+  start(): void {
+    this.status = "active";
+  }
+
+  update(_deltaSeconds: number, context: MissionContext): void {
+    if (this.status !== "active") return;
+
+    if (context.input.interactPressed) {
+      for (const device of this.devices) {
+        if (device.isDisabled) continue;
+        const distance = Vector3.Distance(device.position, context.playerPosition);
+        if (distance <= device.radius) {
+          device.disable();
+        }
+      }
+    }
+
+    const disabledCount = this.devices.filter((device) => device.isDisabled).length;
+    this.progress = this.devices.length === 0 ? 1 : disabledCount / this.devices.length;
+    if (disabledCount === this.devices.length) {
+      this.status = "completed";
+    }
+  }
+
+  getStatusText(): string {
+    const disabledCount = this.devices.filter((device) => device.isDisabled).length;
+    return `${this.label} (${disabledCount}/${this.devices.length})`;
+  }
+}

--- a/apps/web/src/game/missions/objectives/HoldAreaObjective.ts
+++ b/apps/web/src/game/missions/objectives/HoldAreaObjective.ts
@@ -1,0 +1,45 @@
+import type { MissionContext, MissionObjective } from "../MissionTypes";
+import { Vector3 } from "@babylonjs/core/Maths/math.vector";
+
+export class HoldAreaObjective implements MissionObjective {
+  id: string;
+  title: string;
+  optional: boolean;
+  status: MissionObjective["status"] = "notStarted";
+  progress = 0;
+  private readonly center: Vector3;
+  private readonly radius: number;
+  private readonly holdSeconds: number;
+  private timer = 0;
+  private readonly label: string;
+
+  constructor(id: string, title: string, center: Vector3, radius: number, holdSeconds: number, optional = false) {
+    this.id = id;
+    this.title = title;
+    this.optional = optional;
+    this.center = center.clone();
+    this.radius = radius;
+    this.holdSeconds = holdSeconds;
+    this.label = title;
+  }
+
+  start(): void {
+    this.status = "active";
+  }
+
+  update(deltaSeconds: number, context: MissionContext): void {
+    if (this.status !== "active") return;
+    const distance = Vector3.Distance(this.center, context.playerPosition);
+    if (distance <= this.radius) {
+      this.timer = Math.min(this.holdSeconds, this.timer + deltaSeconds);
+    }
+    this.progress = this.holdSeconds === 0 ? 1 : Math.min(1, this.timer / this.holdSeconds);
+    if (this.timer >= this.holdSeconds) {
+      this.status = "completed";
+    }
+  }
+
+  getStatusText(): string {
+    return `${this.label} (${Math.round(this.timer)} / ${Math.round(this.holdSeconds)}s)`;
+  }
+}

--- a/apps/web/src/game/missions/objectives/TimeLimitObjective.ts
+++ b/apps/web/src/game/missions/objectives/TimeLimitObjective.ts
@@ -1,0 +1,38 @@
+import type { MissionContext, MissionObjective } from "../MissionTypes";
+
+export class TimeLimitObjective implements MissionObjective {
+  id: string;
+  title: string;
+  optional: boolean;
+  status: MissionObjective["status"] = "notStarted";
+  progress = 1;
+  private readonly duration: number;
+  private timer = 0;
+  private readonly label: string;
+
+  constructor(id: string, title: string, duration: number, optional = false) {
+    this.id = id;
+    this.title = title;
+    this.optional = optional;
+    this.duration = duration;
+    this.label = title;
+  }
+
+  start(): void {
+    this.status = "active";
+  }
+
+  update(deltaSeconds: number, _context: MissionContext): void {
+    if (this.status !== "active") return;
+    this.timer = Math.min(this.duration, this.timer + deltaSeconds);
+    this.progress = this.duration === 0 ? 1 : 1 - Math.min(1, this.timer / this.duration);
+    if (this.timer >= this.duration) {
+      this.status = "failed";
+    }
+  }
+
+  getStatusText(): string {
+    const remaining = Math.max(0, this.duration - this.timer);
+    return `${this.label} (${remaining.toFixed(0)}s left)`;
+  }
+}


### PR DESCRIPTION
Summary:\n- add mission framework (phases, objectives, events) and mission registry\n- implement objective types: defeat enemies, hold area, disable device, time limit, damage taken\n- add mission HUD overlay and mission selection UI\n- add sample missions: Containment Sweep and Disable the Relay\n\nManual Test Plan:\n- cd apps/web && npm run lint\n- cd apps/web && npm run test\n- cd apps/web && npm run build (note: build may take >3 min in this env)\n- Start game and select mission from dropdown\n- Containment Sweep:\n  - Defeat all hostiles to complete\n  - Optional time limit fails after 45s (shows as failed optional)\n- Disable the Relay:\n  - Press G near each device to disable\n  - Hold the relay zone for 20s (progress pauses if you leave)\n  - Optional damage cap fails if you take >30 damage\n- Press P to restart the current mission (respawns enemies/devices)\n- Force failure: let player die (health to 0)\n\nKeybind notes:\n- G interact (disable devices)\n- P restart mission\n\nCloses #8